### PR TITLE
Replace magic number with mathmatical constant Pi

### DIFF
--- a/contents/main5.js
+++ b/contents/main5.js
@@ -59,7 +59,7 @@ function pubMotorValues(){
         var rot = $('#vel_rot').html();
 
         fw = parseInt(fw)*0.001;
-        rot = 3.141592*parseInt(rot)/180;
+        rot = Math.PI*parseInt(rot)/180;
         var v = new ROSLIB.Message({linear:{x:fw,y:0,z:0}, angular:{x:0,y:0,z:rot}});
         vel.publish(v);
 }


### PR DESCRIPTION
円周率が近似値で記入されていたのですが、Math.PIで置き換えた方が良いと思いました。